### PR TITLE
Replace `gcr.io` images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM gcr.io/distroless/static:nonroot
+FROM docker.io/library/alpine:3.21 as runtime
 
-WORKDIR /
-COPY scheduler-canary-controller manager
-USER 65532:65532
+RUN \
+  apk add --update --no-cache \
+    bash \
+    curl \
+    ca-certificates \
+    tzdata
 
 ENTRYPOINT ["/manager"]
+COPY scheduler-canary-controller manager
+
+USER 65536:0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.2
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
`gcr.io` is deprecated and will be removed https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown.

Docker file is from one of our other controllers.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
